### PR TITLE
Remove socket files on start

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -15,5 +15,6 @@ function setTimeZone {
 
 setTimeZone
 service fail2ban stop
+rm -f /var/run/fail2ban/*
 service fail2ban start
 tailf /var/log/fail2ban.log


### PR DESCRIPTION
Remove the socket files on start of the container.
Otherwise fail2ban might not start on a container restart because they were not removed on shutdown.